### PR TITLE
Align package.json with published npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cookies.js",
-  "version": "1.0.0",
+  "name": "doc-cookies",
+  "version": "1.1.0",
   "description": "Simple cookie framework with full Unicode support ",
   "main": "cookies.js",
   "scripts": {


### PR DESCRIPTION
I updated the package name so it matches the published package:
https://www.npmjs.com/package/doc-cookies

Once this is merged, I hope @evanmuller could publish it.